### PR TITLE
Enhance TPS screen to be actually readable

### DIFF
--- a/src/main/java/com/forgecraft/mods/bridge/client/BridgeClientData.java
+++ b/src/main/java/com/forgecraft/mods/bridge/client/BridgeClientData.java
@@ -5,6 +5,7 @@ import com.forgecraft.mods.bridge.structs.TickTimeHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,13 +17,15 @@ public enum BridgeClientData {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BridgeClientData.class);
 
-    private HashMap<ResourceLocation, TickTimeHolder> serverTps = new HashMap<>();
-
-    public void setServerTps(Map<ResourceLocation, TickTimeHolder> serverTps) {
-        this.serverTps = new HashMap<>(serverTps);
+    @Nullable
+    private TPSPacket serverTps;
+    
+    public void setServerTps(@Nullable TPSPacket packet) {
+        this.serverTps = packet;
     }
 
-    public HashMap<ResourceLocation, TickTimeHolder> getServerTps() {
+    @Nullable
+    public TPSPacket getServerTps() {
         return serverTps;
     }
 
@@ -33,10 +36,10 @@ public enum BridgeClientData {
             return;
         }
 
-        connection.send(new TPSPacket(HashMap.newHashMap(0)));
+        connection.send(new TPSPacket());
     }
 
     public void clearServerTps() {
-        serverTps.clear();
+        serverTps = null;
     }
 }

--- a/src/main/java/com/forgecraft/mods/bridge/client/network/TPSReplyHandler.java
+++ b/src/main/java/com/forgecraft/mods/bridge/client/network/TPSReplyHandler.java
@@ -6,6 +6,6 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 public class TPSReplyHandler {
     public static void onClient(final TPSPacket data, final IPayloadContext context) {
-        context.enqueueWork(() -> BridgeClientData.INSTANCE.setServerTps(data.dimensionMap()));
+        context.enqueueWork(() -> BridgeClientData.INSTANCE.setServerTps(data));
     }
 }

--- a/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
+++ b/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
@@ -16,8 +16,11 @@ import net.minecraft.client.gui.layouts.LinearLayout;
 import net.minecraft.client.gui.layouts.LinearLayout.Orientation;
 import net.minecraft.client.gui.layouts.SpacerElement;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.HoverEvent.Action;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.util.TimeUtil;
@@ -172,7 +175,7 @@ public class TPSScreen extends Screen {
 
                 for (Map.Entry<ResourceLocation, TickTimeHolder> entry : tps.dimensionMap().entrySet()) {
                     final ResourceLocation location = entry.getKey();
-                    final Component locationComponent = Component.translatableWithFallback(location.toLanguageKey("dimensions"), location.toString());
+                    final Component locationComponent = Component.translatableWithFallback(location.toLanguageKey("dimension"), location.toString());
                     final FilledEntry filledEntry = new FilledEntry(location.toString(), locationComponent, entry.getValue());
                     this.allEntries.add(filledEntry);
                 }

--- a/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
+++ b/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
@@ -1,28 +1,108 @@
 package com.forgecraft.mods.bridge.client.screens;
 
 import com.forgecraft.mods.bridge.client.BridgeClientData;
+import com.forgecraft.mods.bridge.client.screens.TPSScreen.TPSInformationList.Entry;
+import com.forgecraft.mods.bridge.network.TPSPacket;
 import com.forgecraft.mods.bridge.structs.TickTimeHolder;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.components.events.ContainerEventHandler;
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.layouts.LinearLayout.Orientation;
+import net.minecraft.client.gui.layouts.SpacerElement;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.util.TimeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class TPSScreen extends Screen {
     private static final DecimalFormat TIME_FORMATTER = new DecimalFormat("########0.000");
+    private final HeaderAndFooterLayout layout = new HeaderAndFooterLayout(this);
+    @Nullable
+    private TPSInformationList tpsList;
+    @Nullable
+    private EditBox search;
     private Instant lastRequest = Instant.now();
+    private int lastKnownHash;
 
     public TPSScreen() {
-        super(Component.literal("TPS Screen"));
+        super(Component.literal("TPS Information"));
         requestTPSData(); // Request data when the screen is created
     }
 
     private void requestTPSData() {
         BridgeClientData.INSTANCE.requestServerTpsUpdate();
         System.out.printf("Requested TPS data at %s%n", Instant.now().toString());
+    }
+
+    private static final int DIMENSION_NAME_WIDTH = 200;
+    private static final int MEAN_TICK_TIME_WIDTH = 100;
+    private static final int MEAN_TPS_WIDTH = 100;
+    private static final int COLUMN_GAP = 4;
+
+    @Override
+    protected void init() {
+        // Screen title
+        this.layout.addTitleHeader(Component.literal("TPS Information"), this.font);
+
+        final LinearLayout contentContainer = this.layout.addToContents(new LinearLayout(this.width, this.layout.getContentHeight(), Orientation.VERTICAL));
+        contentContainer.defaultCellSetting().alignHorizontallyCenter().alignVerticallyMiddle();
+        int leftPadding = TPSInformationList.ROW_PADDING + (2 * 2); // 2px * 2 sides (left and right)
+
+        // Header information
+        final LinearLayout header = contentContainer.addChild(new LinearLayout(this.width, 0, Orientation.HORIZONTAL));
+        header.addChild(SpacerElement.width(leftPadding));
+        header.addChild(new StringWidget(DIMENSION_NAME_WIDTH, font.lineHeight, Component.literal("Dimension name").withStyle(ChatFormatting.UNDERLINE), this.font).alignLeft());
+        header.addChild(SpacerElement.width(COLUMN_GAP));
+        header.addChild(new StringWidget(MEAN_TICK_TIME_WIDTH, font.lineHeight, Component.literal("Mean tick time").withStyle(ChatFormatting.UNDERLINE), this.font).alignLeft());
+        header.addChild(SpacerElement.width(COLUMN_GAP));
+        header.addChild(new StringWidget(MEAN_TPS_WIDTH, font.lineHeight, Component.literal("Mean TPS").withStyle(ChatFormatting.UNDERLINE), this.font).alignLeft());
+
+        // The actual list
+        contentContainer.addChild(SpacerElement.height(4));
+        this.tpsList = contentContainer.addChild(new TPSInformationList(this.layout.getContentHeight() - font.lineHeight - 4 - 6 - (font.lineHeight + 5)));
+        contentContainer.addChild(SpacerElement.height(6));
+
+        // Search bar
+        this.search = contentContainer.addChild(new EditBox(this.font, DIMENSION_NAME_WIDTH, this.font.lineHeight + 5, Component.translatable("fml.menu.mods.search")));
+        this.search.setMaxLength(64);
+        this.search.setHint(Component.translatable("fml.menu.mods.search").withStyle(ChatFormatting.GRAY));
+        this.search.setFocused(false);
+        this.search.setCanLoseFocus(true);
+        this.search.setResponder(this::onSearchBoxEdited);
+
+        // Back button
+        this.layout.addToFooter(Button.builder(CommonComponents.GUI_BACK, button -> this.onClose()).build());
+
+        this.layout.visitWidgets(this::addRenderableWidget);
+        this.repositionElements();
+    }
+
+    private void onSearchBoxEdited(String newValue) {
+        if (tpsList != null) {
+            tpsList.updateVisibleEntries();
+        }
+    }
+
+    @Override
+    protected void repositionElements() {
+        layout.arrangeElements();
     }
 
     @Override
@@ -47,19 +127,177 @@ public class TPSScreen extends Screen {
             lastRequest = Instant.now();
         }
 
-        HashMap<ResourceLocation, TickTimeHolder> serverTps = BridgeClientData.INSTANCE.getServerTps();
-        if (serverTps.isEmpty()) {
-            pGuiGraphics.drawString(this.font, "No data", 10, 10, 0xFFFFFF);
-            return;
+        TPSPacket serverTps = BridgeClientData.INSTANCE.getServerTps();
+        if (tpsList != null) {
+            tpsList.updateAllEntries(serverTps);
+        }
+    }
+
+    private int calculateTPSColor(double tps) {
+        assert this.minecraft != null && this.minecraft.level != null;
+        float maxTPS = TimeUtil.MILLISECONDS_PER_SECOND / this.minecraft.level.tickRateManager().millisecondsPerTick();
+
+        // 0 degrees (0F) is red, 120 degrees (0.33F) is green
+        return Mth.hsvToRgb((float) (Mth.inverseLerp(tps, 0, maxTPS) * 0.33F), 1F, 1F);
+    }
+
+    class TPSInformationList extends ObjectSelectionList<Entry> {
+        private final List<FilledEntry> allEntries = new ArrayList<>();
+        static final int ROW_PADDING = 32;
+
+        public TPSInformationList(int height) {
+            //noinspection DataFlowIssue (minecraft is known to be non-null here)
+            super(TPSScreen.this.minecraft, DIMENSION_NAME_WIDTH + COLUMN_GAP + MEAN_TICK_TIME_WIDTH + COLUMN_GAP + MEAN_TPS_WIDTH, height, 0, 13);
+            // Item height is 13: 2 (padding) + 9 (line) + 2 (padding)
+            this.addEntry(new EmptyEntry());
         }
 
-        int y = 10;
-        for (ResourceLocation dimension : serverTps.keySet()) {
-            TickTimeHolder tps = serverTps.get(dimension);
-            pGuiGraphics.drawString(this.font, dimension.toString(), 10, y, 0xFFFFFF);
-            pGuiGraphics.drawString(this.font, "Mean tick time: " + TIME_FORMATTER.format(tps.meanTickTime()) + "ms", 10, y + 10, 0xFFFFFF);
-            pGuiGraphics.drawString(this.font, "Mean TPS: " + TIME_FORMATTER.format(tps.meanTPS()), 10, y + 20, 0xFFFFFF);
-            y += 30;
+        private void updateAllEntries(@Nullable TPSPacket tps) {
+            // Intelligently update only when the object has changed
+            // Using the hashCode to avoid holding the (previous) object in memory for comparison
+            final int hash = Objects.hashCode(tps);
+            if (hash == TPSScreen.this.lastKnownHash) return; // Do nothing, still up to date
+            TPSScreen.this.lastKnownHash = hash;
+
+            this.allEntries.clear();
+            if (tps != null) {
+                final TickTimeHolder overallHolder = tps.overall();
+                //noinspection NoTranslation
+                final FilledEntry overall = new FilledEntry("overall",
+                        Component.literal("Overall").withStyle(ChatFormatting.BOLD),
+                        Component.literal(TIME_FORMATTER.format(overallHolder.meanTickTime()) + "ms").withStyle(ChatFormatting.BOLD),
+                        Component.literal(TIME_FORMATTER.format(overallHolder.meanTPS())).withStyle(ChatFormatting.BOLD).withColor(calculateTPSColor(overallHolder.meanTPS())),
+                        Component.translatable("Overall mean tick time of %s milliseconds and mean TPS of %s",
+                                TIME_FORMATTER.format(overallHolder.meanTickTime()), TIME_FORMATTER.format(overallHolder.meanTPS())));
+                this.allEntries.add(overall);
+
+                for (Map.Entry<ResourceLocation, TickTimeHolder> entry : tps.dimensionMap().entrySet()) {
+                    final ResourceLocation location = entry.getKey();
+                    final Component locationComponent = Component.translatableWithFallback(location.toLanguageKey("dimensions"), location.toString());
+                    final FilledEntry filledEntry = new FilledEntry(location.toString(), locationComponent, entry.getValue());
+                    this.allEntries.add(filledEntry);
+                }
+            }
+            updateVisibleEntries();
+        }
+
+        private void updateVisibleEntries() {
+            // Store last selected, to reselect later on
+            String lastSelected = null;
+            if (this.getSelected() instanceof FilledEntry entry) {
+                lastSelected = entry.location;
+            }
+
+            this.clearEntries();
+            if (allEntries.isEmpty()) {
+                // No data -- no entries
+                this.addEntry(new EmptyEntry());
+                return;
+            }
+
+            for (FilledEntry entry : allEntries) {
+                if (search != null && !search.getValue().isEmpty()) {
+                    // Filter based on search value
+                    final String locationName = entry.locationComponent.getString();
+                    if (!locationName.contains(search.getValue())) {
+                        // Does not contain search value -- discard
+                        continue;
+                    }
+                }
+                this.addEntry(entry);
+
+                // Reselect if possible
+                if (entry.location.equalsIgnoreCase(lastSelected)) {
+                    this.setSelected(entry);
+                }
+            }
+        }
+
+        @Override
+        public int getRowWidth() {
+            return this.width - ROW_PADDING;
+        }
+
+        @Override
+        protected void renderHeader(@NotNull GuiGraphics guiGraphics, int x, int y) {
+            guiGraphics.drawString(TPSScreen.this.font, Component.literal("Dimension name").withStyle(ChatFormatting.GRAY), x, y, 0xFFFFFF);
+            x += DIMENSION_NAME_WIDTH + COLUMN_GAP;
+            guiGraphics.drawString(TPSScreen.this.font, Component.literal("Mean tick time").withStyle(ChatFormatting.GRAY), x, y, 0xFFFFFF);
+            x += MEAN_TICK_TIME_WIDTH + COLUMN_GAP;
+            guiGraphics.drawString(TPSScreen.this.font, Component.literal("Mean TPS").withStyle(ChatFormatting.GRAY), x, y, 0xFFFFFF);
+        }
+
+        abstract static class Entry extends ObjectSelectionList.Entry<Entry> {
+        }
+
+        class EmptyEntry extends Entry {
+            @Override
+            public @NotNull Component getNarration() {
+                return Component.literal("No data");
+            }
+
+            @Override
+            public void render(@NotNull GuiGraphics guiGraphics, int index, int top, int left, int height, int width,
+                               int mouseX, int mouseY, boolean focused, float partialTick) {
+                top += 1; // Add a bit more padding
+                guiGraphics.drawCenteredString(TPSScreen.this.font, Component.literal("No data"), TPSScreen.this.width / 2, top, 0xFFFFFF);
+            }
+
+            @Override
+            public boolean mouseClicked(double mouseX, double mouseY, int button) {
+                Entry current = TPSInformationList.this.getFocused();
+                if (current != this && current instanceof ContainerEventHandler handler) {
+                    handler.setFocused(null);
+                }
+
+                TPSInformationList.this.setFocused(this);
+                TPSInformationList.this.setDragging(true);
+                return false;
+            }
+        }
+
+        class FilledEntry extends Entry {
+            final String location;
+            final Component locationComponent;
+            final Component meanTickTimeComponent;
+            final Component meanTPSComponent;
+            final Component narration;
+
+            // For dimensions
+            FilledEntry(String location, Component locationComponent, TickTimeHolder tickTimeHolder) {
+                this.location = location;
+                this.locationComponent = locationComponent;
+                this.meanTickTimeComponent = Component.literal(TIME_FORMATTER.format(tickTimeHolder.meanTickTime()) + "ms");
+                this.meanTPSComponent = Component.literal(TIME_FORMATTER.format(tickTimeHolder.meanTPS())).withColor(calculateTPSColor(tickTimeHolder.meanTPS()));
+                //noinspection NoTranslation
+                this.narration = Component.translatable("Dimension %s with mean tick time of %s milliseconds and mean TPS of %s",
+                        location, TIME_FORMATTER.format(tickTimeHolder.meanTickTime()), TIME_FORMATTER.format(tickTimeHolder.meanTPS()));
+            }
+
+            // Specifically for the overall entry
+            FilledEntry(String location, Component locationComponent, Component meanTickTimeComponent, Component meanTPSComponent, Component narration) {
+                this.location = location;
+                this.locationComponent = locationComponent;
+                this.meanTickTimeComponent = meanTickTimeComponent;
+                this.meanTPSComponent = meanTPSComponent;
+                this.narration = narration;
+            }
+
+            @Override
+            public @NotNull Component getNarration() {
+                return narration;
+            }
+
+            @Override
+            public void render(@NotNull GuiGraphics guiGraphics, int index, int top, int left, int height, int width,
+                               int mouseX, int mouseY, boolean focused, float partialTick) {
+                top += 1; // Add a bit more padding
+                guiGraphics.drawString(TPSScreen.this.font, locationComponent, left, top, 0xFFFFFF);
+                left += DIMENSION_NAME_WIDTH + COLUMN_GAP;
+                guiGraphics.drawString(TPSScreen.this.font, meanTickTimeComponent, left, top, 0xFFFFFF);
+                left += MEAN_TICK_TIME_WIDTH + COLUMN_GAP;
+                guiGraphics.drawString(TPSScreen.this.font, meanTPSComponent, left, top, 0xFFFFFF);
+            }
         }
     }
 }

--- a/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
+++ b/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
@@ -15,12 +15,12 @@ import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
 import net.minecraft.client.gui.layouts.LinearLayout;
 import net.minecraft.client.gui.layouts.LinearLayout.Orientation;
 import net.minecraft.client.gui.layouts.SpacerElement;
+import net.minecraft.client.gui.navigation.ScreenAxis;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.HoverEvent.Action;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.util.TimeUtil;
@@ -175,8 +175,10 @@ public class TPSScreen extends Screen {
 
                 for (Map.Entry<ResourceLocation, TickTimeHolder> entry : tps.dimensionMap().entrySet()) {
                     final ResourceLocation location = entry.getKey();
-                    final Component locationComponent = Component.translatableWithFallback(location.toLanguageKey("dimension"), location.toString());
-                    final FilledEntry filledEntry = new FilledEntry(location.toString(), locationComponent, entry.getValue());
+                    final String locationStr = location.toString();
+                    final Component locationComponent = Component.translatableWithFallback(location.toLanguageKey("dimension"), locationStr)
+                            .withStyle(style -> style.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(locationStr))));
+                    final FilledEntry filledEntry = new FilledEntry(locationStr, locationComponent, entry.getValue());
                     this.allEntries.add(filledEntry);
                 }
             }
@@ -295,10 +297,18 @@ public class TPSScreen extends Screen {
                                int mouseX, int mouseY, boolean focused, float partialTick) {
                 top += 1; // Add a bit more padding
                 guiGraphics.drawString(TPSScreen.this.font, locationComponent, left, top, 0xFFFFFF);
+                int locationLeft = left, locationTop = top;
                 left += DIMENSION_NAME_WIDTH + COLUMN_GAP;
                 guiGraphics.drawString(TPSScreen.this.font, meanTickTimeComponent, left, top, 0xFFFFFF);
                 left += MEAN_TICK_TIME_WIDTH + COLUMN_GAP;
                 guiGraphics.drawString(TPSScreen.this.font, meanTPSComponent, left, top, 0xFFFFFF);
+
+                final ScreenRectangle locationRect = ScreenRectangle.of(ScreenAxis.HORIZONTAL,
+                        locationLeft, locationTop,
+                        TPSScreen.this.font.width(locationComponent), TPSScreen.this.font.lineHeight);
+                if (locationRect.containsPoint(mouseX, mouseY)) {
+                    guiGraphics.renderComponentHoverEffect(TPSScreen.this.font, locationComponent.getStyle(), mouseX, mouseY);
+                }
             }
         }
     }

--- a/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
+++ b/src/main/java/com/forgecraft/mods/bridge/client/screens/TPSScreen.java
@@ -48,7 +48,6 @@ public class TPSScreen extends Screen {
 
     private void requestTPSData() {
         BridgeClientData.INSTANCE.requestServerTpsUpdate();
-        System.out.printf("Requested TPS data at %s%n", Instant.now().toString());
     }
 
     private static final int DIMENSION_NAME_WIDTH = 200;

--- a/src/main/java/com/forgecraft/mods/bridge/network/TPSPacket.java
+++ b/src/main/java/com/forgecraft/mods/bridge/network/TPSPacket.java
@@ -65,14 +65,14 @@ public record TPSPacket(
                     times = UNLOADED;
                 }
 
-                double levelTickTime = Stats.meanOf(times) * 1.0E-6D;
+                double levelTickTime = Stats.meanOf(times) / TimeUtil.NANOSECONDS_PER_MILLISECOND;
                 double levelTPS = TimeUtil.MILLISECONDS_PER_SECOND / Math.max(levelTickTime, server.tickRateManager().millisecondsPerTick());
 
                 dimensionData.put(dimension.dimension().location(), new TickTimeHolder(levelTickTime, levelTPS));
             }
 
             long[] times = server.getTickTimesNanos();
-            double overallTickTime = Stats.meanOf(times) * 1.0E-6D;
+            double overallTickTime = Stats.meanOf(times) / TimeUtil.NANOSECONDS_PER_MILLISECOND;
             double overallTPS = TimeUtil.MILLISECONDS_PER_SECOND / Math.max(overallTickTime, server.tickRateManager().millisecondsPerTick());
             TickTimeHolder overallData = new TickTimeHolder(overallTickTime, overallTPS);
 

--- a/src/main/java/com/forgecraft/mods/bridge/network/TPSPacket.java
+++ b/src/main/java/com/forgecraft/mods/bridge/network/TPSPacket.java
@@ -20,19 +20,26 @@ import java.util.HashMap;
 import java.util.Map;
 
 public record TPSPacket(
-    Map<ResourceLocation, TickTimeHolder> dimensionMap
+        Map<ResourceLocation, TickTimeHolder> dimensionMap,
+        TickTimeHolder overall
 ) implements CustomPacketPayload {
     private static final Logger LOGGER = LoggerFactory.getLogger(TPSPacket.class);
 
     public static final Type<TPSPacket> TYPE = new Type<>(Bridge.location("tps_reply"));
 
-    private static final long[] UNLOADED = new long[] { 0 };
+    private static final long[] UNLOADED = new long[]{0};
 
     public static final StreamCodec<FriendlyByteBuf, TPSPacket> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.map(HashMap::new, ResourceLocation.STREAM_CODEC, TickTimeHolder.STEAM_CODEC),
             TPSPacket::dimensionMap,
+            TickTimeHolder.STEAM_CODEC,
+            TPSPacket::overall,
             TPSPacket::new
     );
+
+    public TPSPacket() {
+        this(Map.of(), new TickTimeHolder(0, 0));
+    }
 
     @Override
     public @NotNull Type<? extends CustomPacketPayload> type() {
@@ -48,9 +55,9 @@ public record TPSPacket(
                 return;
             }
 
-            // Find the TPS data for each dimension
+            // Find the TPS data for each dimension and overall
             // Most of this logic is from the Neoforge TPS command
-            Map<ResourceLocation, TickTimeHolder> tpsData = new HashMap<>();
+            Map<ResourceLocation, TickTimeHolder> dimensionData = new HashMap<>();
             for (ServerLevel dimension : server.getAllLevels()) {
                 long[] times = server.getTickTime(dimension.dimension());
 
@@ -61,11 +68,16 @@ public record TPSPacket(
                 double levelTickTime = Stats.meanOf(times) * 1.0E-6D;
                 double levelTPS = TimeUtil.MILLISECONDS_PER_SECOND / Math.max(levelTickTime, server.tickRateManager().millisecondsPerTick());
 
-                tpsData.put(dimension.dimension().location(), new TickTimeHolder(levelTickTime, levelTPS));
+                dimensionData.put(dimension.dimension().location(), new TickTimeHolder(levelTickTime, levelTPS));
             }
 
+            long[] times = server.getTickTimesNanos();
+            double overallTickTime = Stats.meanOf(times) * 1.0E-6D;
+            double overallTPS = TimeUtil.MILLISECONDS_PER_SECOND / Math.max(overallTickTime, server.tickRateManager().millisecondsPerTick());
+            TickTimeHolder overallData = new TickTimeHolder(overallTickTime, overallTPS);
+
             // Send the TPS data back to the client
-            context.reply(new TPSPacket(tpsData));
+            context.reply(new TPSPacket(dimensionData, overallData));
         });
     }
 }


### PR DESCRIPTION
This PR enhances the TPS screen shown by `/fc dev show TPS` to be actually readable and understandable, instead of the (professed) quick and dirty implementation made while this mod was being initially coded.

The new TPS screen features:
- A selectable list which contains the information for each dimension's TPS and tick time, including an entry for the overall server TPS and tick time;
- Dimension names using the FTB Lib convention of `dimensions.<namespace>.<path>`, with a fallback to the dimension resource location, and an on-hover tooltip for the full dimension resource location in all cases;
- Colorized TPS values ranging from red to green, for quick visual identification of TPS values;
- A search bar, for filtering based on visible dimension name (not the dimension location!); and
- Narrator compatibility, as much as possible -- each entry is read out by the narrator in an understandable manner. (This is why the Overall entry is in the list rather than separate.)

This PR also removes a debugging print statement leftover in the TPS request method in the TPS screen, to avoid cluttering the console/log.

<hr>

Sample screenshot of the TPS screen on a singleplayer world:
![Screenshot of the TPS screen on a singleplayer world, showing TPS and mean tick time values for the Overworld, Nether, and The End dimensions](https://github.com/user-attachments/assets/9808cab2-659e-4afc-bf4a-da04cf5e56c7)

<details>
<summary>Screenshot of the TPS screen when no data is provided by the server</summary>

![Screenshot of the TPS screen showing a "No data" indicator](https://github.com/user-attachments/assets/a6bb5c9d-06ce-4d3c-a86a-17e7ce6174a2)

</details>
